### PR TITLE
Upgrade Python versions supported

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -138,7 +138,7 @@ jobs:
     # NOTE: we assume that dist/ contains a built sdist (and only that).
     #       Yes, we could be more defensively, but What Could Go Wrong?™
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -62,14 +62,14 @@ jobs:
         path: nle_test_ci_${{ github.sha }}.tar.gz
 
   test_sdist:
-    name: Test sdist on MacOS w/ Py3.8
+    name: Test sdist on MacOS w/ Py3.11
     needs: test_repo
     runs-on: macos-latest
     steps:
-    - name: Setup Python 3.8 env
+    - name: Setup Python 3.11 env
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Ensure latest pip & wheel
       run: "python -m pip install -q --upgrade pip wheel"
     - name: Install dependencies

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-20.04, macos-latest]
       fail-fast: false
     steps:

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
     - name: Setup Python ${{ matrix.python-version }} env

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ venv.bak/
 
 # IDE
 .idea/
+.vscode/
 
 # Rope project settings
 .ropeproject
@@ -205,3 +206,6 @@ nle/version.py
 nle_data/
 nle/fbs/
 nle/nethackdir
+
+# Generated during tests
+nle.ttyrec3.bz2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 24.3.0
     hooks:
     - id: black
       language_version: python3.8
 -   repo: https://github.com/pycqa/flake8
-    rev: '3.9.2'
+    rev: '7.0.0'
     hooks:
     - id: flake8
       additional_dependencies: [flake8-bugbear]
@@ -23,7 +23,7 @@ repos:
         language: system
         files: ^(src\/nle|include\/nle|win\/rl|sys\/unix\/nle).*\.(c|cc|cxx|cpp|cu|h|hpp|hxx|cuh|proto)$
 -   repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/nle/scripts/collect_env.py
+++ b/nle/scripts/collect_env.py
@@ -293,9 +293,9 @@ def get_env_info():
         cuda_available_str = torch.cuda.is_available()
         cuda_version_str = torch.version.cuda
     else:
-        torch_version_str = (
+        torch_version_str = cuda_available_str = cuda_version_str = (
             torch_debug_mode_str
-        ) = cuda_available_str = cuda_version_str = "N/A"
+        ) = "N/A"
 
     return SystemEnv(
         nle_version=nle_version,

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ entry_points = {
 extras_deps = {
     "dev": [
         "pre-commit>=2.0.1",
+        "isort>=5.13.2",
         "black>=19.10b0",
         "cmake_format>=0.6.10",
         "flake8>=3.7",


### PR DESCRIPTION
Note: Copy of https://github.com/facebookresearch/nle/pull/371

- Remove testing for Python 3.6 & Python 3.7 as those versions are end-of-life. See here: [Status of Python versions](https://devguide.python.org/versions/)
- Add testing for Python 3.10 & Python 3.11
- Fix minor Black complaint
- Update link to gh-action-pypi-publish. See note in [PyPI publish GitHub Action README](https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/README.md)
- Update library versions in pre-commit configuration